### PR TITLE
Remove scroll for overflow

### DIFF
--- a/app/assets/stylesheets/visitors.scss
+++ b/app/assets/stylesheets/visitors.scss
@@ -92,7 +92,6 @@ body {
 		background-image: none;
 		background-position: center;
 		background-repeat: no-repeat;
-		overflow: scroll;
 		// background-repeat: no-repeat repeat;
 		background-size: 90%;
 		color: rgba(255,255,255,0.75);


### PR DESCRIPTION
Nice blog website! I've seen it so many times now and everytime that scrollbar on the nav irritates me, so I fixed it. Instead of forcing the scroll behaviour, just let it happen if necessary.
This scroll bar basically does nothing because it's not needed (at least on desktop)

Before:
![image](https://user-images.githubusercontent.com/63303990/228856321-9b9bcfca-b241-4c0b-94dc-8888c6593840.png)

After:
![image](https://user-images.githubusercontent.com/63303990/228856180-a5e9e34e-e4f3-4a9b-9f1a-5da32041d76e.png)
